### PR TITLE
fix: ci / cd fixes, builds first for lib then docs, add trivy instead…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,12 +173,16 @@ jobs:
         run: pnpm install --frozen-lockfile --prod=false
       - name: Run pnpm audit (non-blocking)
         run: pnpm audit || true
-      - name: Run gitleaks secret scan
-        uses: gitleaks/gitleaks-action@v2
+      - name: Trivy secret scan (repo)
+        uses: aquasecurity/trivy-action@0.20.0
         continue-on-error: false
         with:
-          config: ''
-          args: detect --no-git -v
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'secret'
+          format: 'table'
+          exit-code: '1'
+          hide-progress: true
       - name: TruffleHog secret scan (diff)
         uses: trufflesecurity/trufflehog@v3.90.5
         continue-on-error: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,15 +30,27 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: website/package-lock.json
       
+      # Build the library first so the website can depend on local dist files
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install repo dependencies (no scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build library
+        run: pnpm run build
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
       
-      - name: Install dependencies
-        run: npm ci
+      - name: Install website dependencies (no scripts)
+        run: npm ci --ignore-scripts
         working-directory: ./website
       
       - name: Build website

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -27,8 +27,7 @@ jobs:
       
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
+  # Use version from packageManager in package.json to avoid mismatch
           
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -22,6 +22,7 @@ Magiclogger CI currently does:
 4. Build artifacts (ESM + CJS) and upload dist
 5. Draft release notes maintenance (Release Drafter) when on `master` / `main`
 6. Optional coverage upload to Codecov
+7. Secret scanning with Trivy (free, no license required)
 
 It does **not** auto-publish on merge to `master`; publishing only happens when a semver tag (`vX.Y.Z`) is pushed.
 
@@ -37,6 +38,36 @@ The pipeline is defined in these workflow files:
 | `.github/workflows/release.yml` | Tag-triggered build + npm publish + GitHub Release |
 
 No `.releaserc` / semantic-release is used; versioning is manual + tags.
+
+## Security Scanning (Secrets)
+
+We use Trivy for secret scanning in CI. This replaces the previous gitleaks step that required a paid org license.
+
+- License/keys: None required for our usage.
+- Extra dependencies in repo: None. The GitHub Action downloads Trivy.
+- Network: Not required for secret-only scanning (no vulnerability DB needed).
+
+CI step (excerpt):
+
+```yaml
+- name: Trivy secret scan (repo)
+   uses: aquasecurity/trivy-action@0.20.0
+   continue-on-error: false
+   with:
+      scan-type: 'fs'
+      scan-ref: '.'
+      scanners: 'secret'
+      format: 'table'
+      exit-code: '1'
+      hide-progress: true
+```
+
+Local usage (optional):
+- Windows (Chocolatey): `choco install trivy`
+- macOS (Homebrew): `brew install trivy`
+- Docker: `docker run --rm -v "$PWD":/project -w /project aquasec/trivy:latest fs --scanners secret .`
+
+Exit code 1 indicates secrets found; rotate any exposed credentials and remove them from history as needed.
 
 ## Versioning Strategy
 
@@ -131,6 +162,7 @@ To skip CI for non-critical doc-only commits you can append `[skip ci]` to the c
 |--------|----------|---------|
 | `NPM_TOKEN` | For publishing | Auth token with publish rights to npm registry (automation / granular token recommended) |
 | `CODECOV_TOKEN` | Optional | Reliable Codecov uploads for coverage reporting |
+| (none for Trivy) | — | Trivy secret scan requires no license or API keys |
 
 Add via: Repository → Settings → Secrets and variables → Actions → New repository secret.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,6 +19,7 @@ No publish occurs without a semver tag (`v*`). Draft release notes are maintaine
 |------------|----------|---------|-------|
 | `NPM_TOKEN` | GitHub Repo → Settings → Secrets → Actions | Publish to npm registry | Use automation token with publish scope only |
 | `CODECOV_TOKEN` (optional) | Same | Coverage upload reliability | Not required for release |
+| (none for Trivy) | — | Secret scanning in CI | Trivy requires no API keys or license for this workflow |
 
 ### Creating an npm Automation Token
 1. Log into https://www.npmjs.com/.
@@ -137,6 +138,7 @@ Secrets are environment‑scoped automatically per workflow; no plaintext loggin
 | Tests | All pass on matrix |
 | Coverage | ~95% target (enforced via docs + Codecov threshold if enabled) |
 | Build | Bundle builds (CJS + ESM) |
+| Secret Scan | Trivy reports no hardcoded secrets in the repo |
 
 ## Frequently Asked Questions
 **Q: Can I publish from a feature branch?**  
@@ -165,4 +167,4 @@ A: Ensure Git client supports signed provenance (Node 18+, Actions OIDC) and tha
 - Add CodeQL / OSS scan for security.
 
 ---
-_Last updated: YYYY-MM-DD_
+_Last updated: 2025-08-15_

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,12 +5,11 @@
 Magiclogger is a fully typed, high-performance logging library built with TypeScript. This guide provides comprehensive instructions for setting up, developing, and contributing to the project.
 
 ## Prerequisites
- Node.js 16+ recommended (project supports >=14, CI tests 16 / 18 / 20)
- pnpm (preferred) or npm / yarn (Corepack can enable pnpm automatically)
- TypeScript 5.x
-- TypeScript 4.5.0 or higher
+- Node.js 18+ recommended (CI uses 18/20; docs deploy uses Node 20)
+- pnpm (preferred). Corepack can enable pnpm automatically.
+- TypeScript 5.x
 
- Clone the repository and install dependencies (pnpm preferred for lockfile fidelity and speed):
+Clone the repository and install dependencies (pnpm preferred for lockfile fidelity and speed):
 
 ### Installation
 ```bash
@@ -20,9 +19,7 @@ cd magiclogger
 corepack enable
 pnpm install
 ```
-cd magiclogger
-npm install
-```
+
 
 ## Development Workflow
 
@@ -41,36 +38,13 @@ npm install
 | `pnpm preflight` | Full validation (format, lint, test, coverage, build, analysis) |
 | `npm run dev` | Start development mode with file watching |
 | `npm test` | Run test suite |
-```bash
-pnpm dev
-```
 | `npm run format` | Format code with Prettier |
 | `npm run preflight` | Run comprehensive pre-release checks |
-```bash
-pnpm test
-```
-```bash
-npm run dev
-View detailed coverage report:
-```bash
-pnpm test:coverage
-```
+View detailed coverage report with:
+`pnpm test:coverage`
 ## Testing
 
-```bash
-pnpm lint
-```
-npm test
-```
-```bash
-pnpm format
-```
-Magiclogger maintains rigorous test coverage standards:
-
-```bash
-pnpm preflight
-```
-- Lines: 95%
+Magiclogger maintains rigorous test coverage standards (see Codecov docs). Target ~95% lines.
 
 ## Branch & Merge Workflow
 
@@ -211,3 +185,16 @@ Recommended TypeScript configuration:
   }
 }
 ```
+
+## Local Security/Secret Scanning (Optional)
+
+We run Trivy secret scanning in CI. You can mirror this locally to catch issues before pushing:
+
+- macOS: `brew install trivy`
+- Windows: `choco install trivy`
+- Docker (no install):
+  ```bash
+  docker run --rm -v "$PWD":/project -w /project aquasec/trivy:latest fs --scanners secret .
+  ```
+
+Exit code 1 means potential secrets detected; rotate credentials and purge from history if confirmed.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
     "resolveJsonModule": true,
     "strict": true
   },
-  "include": ["src/**/*.ts", "examples/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["examples/**"]
 }


### PR DESCRIPTION
… of github-leaks

## 📋 Summary

fix: ci / cd fixes, builds first for lib then docs, add trivy instead of github-leaks

## 🔗 Related Issues
Closes #

## 📝 Type of Change
- [ ] ✨ Feature
- [ ] 🐛 Fix
- [ ] 💥 Breaking Change
- [ ] 📚 Docs
- [ ] 🧪 Tests
- [ ] 🔧 Build / CI
- [ ] ♻️ Refactor
- [ ] ⚡ Performance
- [ ] 🧹 Chore
- [ ] 📦 Dependencies

## 🧪 Testing
Describe tests added/updated and manual verification steps.

## ✅ Checklist
- [ ] Code follows style (lint passes)
- [ ] Added/updated tests
- [ ] Updated docs / README (if user-facing change)
- [ ] No new ESLint warnings
- [ ] Changes are backward compatible (or noted as breaking)

## 💥 Breaking Changes
If breaking, describe impact and migration path.

## 📸 Screenshots / Logs (optional)

## 📌 Additional Notes

## 🚀 Post-Merge Actions
- [ ] Publish package (if needed)
- [ ] Announce / release notes
